### PR TITLE
Update cypress tests to use beforeEach, pass starter tests

### DIFF
--- a/cypress/integration/homeview_spec.js
+++ b/cypress/integration/homeview_spec.js
@@ -1,15 +1,8 @@
 describe('VegShare, main page view', () => {
   const baseUrl = 'https://veg-share.herokuapp.com'
 
-  beforeAll(() => {
-  //   cy
-  //   .fixture('mockData.json')
-  //   .then((mockData) => {
-  //     cy.intercept('GET', )
-  //   })
-
+  beforeEach(() => {
     cy.visit(baseUrl)
-
   })
 
   it ('should have the correct url for the home page on load', () => {
@@ -19,7 +12,7 @@ describe('VegShare, main page view', () => {
 
   it ('should show the site header', () => {
     cy
-      .get('header .veg-share-title').contains('Veg-Share')
-  })
+      .get('header .veg-share-title').should('contain', 'Veg-Share')
+  });
 
 })


### PR DESCRIPTION
## *Purpose:*
*What does this merge do? Check all that apply.*
- [ ] Adds a new feature
- [ ] Improves an existing feature
- [x] Fixes a bug
- [ ] Cleans up (logs, tests, etc.)


## *Description: What does this PR do?*
> Travis CI build#2 failed due to not recognizing `beforeAll` used in the homeview_spec.
These changes update this spec to use `beforeEach`, passing the cypress tests locally.
Also updates the second test to confirm an assertion.


## *Where should the reviewer start?*
> run tests manually - `npm run cypress`
If successful, merging this PR should trigger a build, viewable to confirm through Travis CI


## *What are the relevant tickets?*
> #18 


## *Concerns / Bugs:*
> Our next step if this does not succeed in confirming our CI is working, will be to revisit the `.travis.yml` file and consider adding instructions to trigger a build on PRs merged to specified branches (_i.e. main_)


## Checklist:
- [ ] I have performed a self-review of my own code
- [x] I have used tests to prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my change
